### PR TITLE
fix(theme): scrollbar hover colour

### DIFF
--- a/themes/xy-zed.json
+++ b/themes/xy-zed.json
@@ -49,7 +49,7 @@
         // "panel.focused_border": null,
         "panel.focused_border": "FF0000", // ?
         "scrollbar.thumb.background": "#aca8ae30", // muted transparent
-        "scrollbar.thumb.hover_background": "#FF0000", // ?
+        "scrollbar.thumb.hover_background": "#746f7730", // darker muted transparent
         "scrollbar.thumb.border": "#ffffff20", // white (very transparent)
         "scrollbar.track.background": "#1b1b1b80", // black (scondary, darkest transparent)
         "scrollbar.track.border": "#ffffff10", // white (lightest transparent)


### PR DESCRIPTION
The colour of the sidebar seems to now be changing to red on hover - so I've tweaked it (see below).

New: <img width="41" alt="Screenshot 2025-05-23 at 17 26 17" src="https://github.com/user-attachments/assets/67423bc5-38f7-4005-a5b8-982e0c79d2e0" />

Old: <img width="59" alt="Screenshot 2025-05-23 at 17 26 43" src="https://github.com/user-attachments/assets/d440e1a3-0021-4d92-ae66-7387fa569330" />

Fixes #6 